### PR TITLE
fix for alphanumeric public article and galley ids

### DIFF
--- a/classes/SolrWebService.inc.php
+++ b/classes/SolrWebService.inc.php
@@ -1567,7 +1567,7 @@ class SolrWebService extends XmlWebService {
 		foreach ($galleys as $galley) {
 			if ($galley->getFileId()) {
 				$locale = $galley->getLocale();
-				$galleyUrl = $router->url($request, $journal->getPath(), 'article', 'download', array(intval($article->getBestArticleId()), intval($galley->getBestGalleyId())));
+				$galleyUrl = $router->url($request, $journal->getPath(), 'article', 'download', array($article->getBestArticleId(), intval($galley->getBestGalleyId())));
 
 				//TODO: Remove next line before finalizing
 				//This is only necessary when testing from a VM with port mappings for port 80. BaseUrl has port 8000, but if the server makes the connection it should use port 80

--- a/classes/SolrWebService.inc.php
+++ b/classes/SolrWebService.inc.php
@@ -1567,7 +1567,7 @@ class SolrWebService extends XmlWebService {
 		foreach ($galleys as $galley) {
 			if ($galley->getFileId()) {
 				$locale = $galley->getLocale();
-				$galleyUrl = $router->url($request, $journal->getPath(), 'article', 'download', array($article->getBestArticleId(), intval($galley->getBestGalleyId())));
+				$galleyUrl = $router->url($request, $journal->getPath(), 'article', 'download', array($article->getBestArticleId(), $galley->getBestGalleyId()));
 
 				//TODO: Remove next line before finalizing
 				//This is only necessary when testing from a VM with port mappings for port 80. BaseUrl has port 8000, but if the server makes the connection it should use port 80


### PR DESCRIPTION
As far as I can tell, the "best" article id can be alphanumeric, e. g. "pub-id::publisher-id" with a value of "A_00340". Casting such an alphanumeric publisher-id to `int` causes the generated URL to be wrong, so the article's full text can not be retrieved and therefore not be indexed.

